### PR TITLE
Support Ubuntu Jammy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,14 @@ Source: bazel
 Section: contrib/devel
 Priority: optional
 Maintainer: Wooks Song <wook16.song@samsung.com>
-Build-Depends: debhelper (>=9), bash, openjdk-8-jdk, zip, unzip, python
+Build-Depends: debhelper (>=9), bash, openjdk-8-jdk, zip, unzip, python | python3, g++-10 | g++-9 | g++-8 | g++-7 | g++-6 | g++-5, gcc-10 | gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5
 Standards-Version: 0.25.2-dist
 Homepage: https://github.com/bazelbuild/bazel
 
 Package: bazel-dist
 Architecture: any
 Multi-Arch: same
-Depends: g++, zlib1g-dev, unzip, bash-completion, python, ${misc:Depends}, ${shlibs:Depends}
+Depends: g++, zlib1g-dev, unzip, bash-completion, python | python3, ${misc:Depends}, ${shlibs:Depends}
 Suggests: openjdk-8-jdk
 Description: Bazel is a tool that automates software builds and tests.
  Supported build tasks include running compilers and linkers to produce

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,8 @@
 export DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-${DEB_HOST_ARCH}
 export BAZEL_JAVAC_OPTS=-J-Xmx2g
+export CXXFLAGS=-Wno-error
+export CFLAGS=-Wno-error
 SRC_ROOT_DIR:=$(shell pwd)
 
 %:
@@ -32,7 +34,14 @@ override_dh_auto_clean:
 	rm -rf ${SRC_ROOT_DIR}/output
 
 ${SRC_ROOT_DIR}/output/bazel:
-	EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" ./compile.sh
+	if [ -f /usr/bin/g++-10 ]; then \
+		echo "g++-10 found. using it to prevent using g++-11 or later"; \
+		sed -i "s|gettid(|__gettid(|" third_party/grpc/src/core/lib/gpr/log_linux.cc ; \
+		if [ -f /usr/bin/python3 ]; then ln -s /usr/bin/python3 python; fi; \
+		PATH=${PATH}:. CC=gcc-10 CXX=g++-10 EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" ./compile.sh ; \
+	else \
+		EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" ./compile.sh ; \
+	fi
 
 override_dh_auto_build: ${SRC_ROOT_DIR}/output/bazel
 


### PR DESCRIPTION
From Jammy, we do not have python anymore. We have python3:
```
The following packages have unmet dependencies:
 builddeps:bazel : Depends: python but it is not installable
```