### PR TITLE
Try older Ubuntu distro.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -34,9 +34,9 @@ override_dh_auto_clean:
 	rm -rf ${SRC_ROOT_DIR}/output
 
 ${SRC_ROOT_DIR}/output/bazel:
+	sed -i "s|gettid(|__gettid(|" third_party/grpc/src/core/lib/gpr/log_linux.cc
 	if [ -f /usr/bin/g++-10 ]; then \
 		echo "g++-10 found. using it to prevent using g++-11 or later"; \
-		sed -i "s|gettid(|__gettid(|" third_party/grpc/src/core/lib/gpr/log_linux.cc ; \
 		if [ -f /usr/bin/python3 ]; then ln -s /usr/bin/python3 python; fi; \
 		PATH=${PATH}:. CC=gcc-10 CXX=g++-10 EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" ./compile.sh ; \
 	else \


### PR DESCRIPTION
Renaming gettid is harmless.
Apply the change for all distro to avoid glibc-related issues.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>